### PR TITLE
Add support for Python 3.10

### DIFF
--- a/adapters/adapters.py
+++ b/adapters/adapters.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-import collections
 import copy
 import six
 
@@ -39,7 +38,7 @@ class Adapter(BaseField):
             adapted_value = field.adapt(value)
             if adapted_value is undefined:
                 continue
-            if isinstance(instance, collections.Mapping):
+            if isinstance(instance, six.moves.collections_abc.Mapping):
                 instance[field_name] = adapted_value
             else:
                 setattr(instance, field_name, adapted_value)

--- a/adapters/helpers.py
+++ b/adapters/helpers.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-import collections
+import six
 
 from .utils import undefined
 
@@ -14,16 +14,16 @@ def get_attribute(obj, attrs):
             return undefined
 
         try:
-            if isinstance(obj, collections.Mapping):
+            if isinstance(obj, six.moves.collections_abc.Mapping):
                 obj = obj[attr]
-            elif isinstance(obj, collections.Iterable):
+            elif isinstance(obj, six.moves.collections_abc.Iterable):
                 obj = obj[int(attr)]
             else:
                 obj = getattr(obj, attr)
         except Exception:
             return undefined
 
-        if isinstance(obj, collections.Callable):
+        if isinstance(obj, six.moves.collections_abc.Callable):
             obj = obj()
 
     return obj

--- a/adapters/utils.py
+++ b/adapters/utils.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import collections
+import six
 
 
 __all__ = ['BindingDict', 'EMPTY_VALUES', 'undefined']
@@ -13,7 +14,7 @@ class undefined:
     pass
 
 
-class BindingDict(collections.MutableMapping):
+class BindingDict(six.moves.collections_abc.MutableMapping):
     def __init__(self, adapter):
         self.adapter = adapter
         self.fields = collections.OrderedDict()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 future
-python-dateutil==2.6.0
+python-dateutil==2.7.0
 six

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     keywords=['adapter pattern'],
     install_requires=[
         'future',
-        'python-dateutil>=2.6.0',
-        'six',
+        'python-dateutil>=2.7.0',
+        'six>=1.13.0',
     ],
 )


### PR DESCRIPTION
This adds support for Python 3.10.

* "Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.10 it will stop working."
* six 1.13.0 added the needed alias `six.moves.collections_abc`.
* python-dateutil 2.7.0 fixed a similar issue related to abstract base classes

```
@illia-v ➜ /workspaces/python-adapters (master) $ python --version
Python 3.10.4
@illia-v ➜ /workspaces/python-adapters (master) $ ./test.sh
.........................
----------------------------------------------------------------------
Ran 25 tests in 0.004s

OK
```